### PR TITLE
Eject live handler

### DIFF
--- a/server.go
+++ b/server.go
@@ -32,7 +32,7 @@ func NewServer(hc IHealthcheck, opts ...func(*serverOptions)) (*Server, error) {
 func (s *Server) Run(ctx context.Context) error {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/live", s.handleLive)
+	mux.HandleFunc("/live", LiveHandler())
 	mux.HandleFunc("/ready", ReadyHandler(s.opts.healthcheck))
 	mux.Handle("/metrics", promhttp.Handler())
 
@@ -61,9 +61,12 @@ func (s *Server) Run(ctx context.Context) error {
 	return nil
 }
 
-func (s *Server) handleLive(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+// LiveHandler return an implementation of /live request.
+func LiveHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}
 }
 
 // ReadyHandler build a http.HandlerFunc from healthcheck.


### PR DESCRIPTION
This is allows users to copy-paste http server to their own code. Usually it requires when project are growing and we need to extend/customize the server